### PR TITLE
Apostrophes, Case-Insensitivity, Reserved Words, and a few tweaks

### DIFF
--- a/tumblrtags.html
+++ b/tumblrtags.html
@@ -7,7 +7,8 @@
 
 </script>
 
-<h1>A Heading for your Tags Page</h1>
-
-<!-- This div is where the tag cloud will be loaded -->
-<div id="taggggs"></div>
+<!-- Tumblr needs the div to be wrapped in paragraph tags to load it correctly. --> 
+<p>
+  <!-- This empty div is where the tags will be loaded -->
+  <div id="taggggs"></div>
+</p>

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -140,7 +140,7 @@ function generateFlowers(tags)
 		
 		tag_url = "/tagged/" + sanitizeTagForURL(t);
 		
-		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + " " + number + "</a></li>";
+		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + "" + " (" + number + ") </a></li>";
 	}
 	flower += "</ul>";	
 	

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -89,6 +89,7 @@ function getTags(user_url)
 	}
 }
 
+//adjust the tag name so that it will work as a URL for that tag
 function sanitizeTagForURL(tag_name)
 {
 	sanitized_tag_name = tag_name;

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -25,6 +25,11 @@ threshold_frequent = 25;	// tags used more than sometimes, but under this many t
 threshold_normal = 50;		// tags used more than frequently, but under this many times, are considered normally-used
 // tags used more than normally will be considered always-used
 
+// caseInsensitive:
+// if true, all tags will be treated as if they were lower-case (this is how Tumblr seems to treat tags)
+// If false, multiple versions of the tag with different capitalizations will be displayed and counted separately.
+caseInsensitive = true;
+
 //global counters
 totalposts = 0;
 totaltags = 0;
@@ -63,6 +68,12 @@ function getTags(user_url)
 		for (var i=0;i<data.response.posts.length;i++){
 			for (var j=0;j<data.response.posts[i].tags.length;j++){
 				temp_tag = data.response.posts[i].tags[j];
+				
+				if( caseInsensitive )
+				{
+					temp_tag = temp_tag.toLowerCase();
+				}
+				
 				if (tags[temp_tag]) {
 					tags[temp_tag]++;
 				}

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -14,6 +14,17 @@
 //you can change this to whatever you want to use on your Tumblr
 your_pathname = 'tags';
 
+//these are used to determine how to set the font-sizes of the tags in the resulting list of tags
+//this way, the most used tags (with the highest usage-count) can have the largest font size
+//while the tags you barely use can have the smallest font size
+//you can set the boundaries between each category here, based on what suits you and your blog.
+
+threshold_barely = 5;		// tags used under this many times are considered barely-used
+threshold_sometimes = 12;	// tags used more than barely, but under this many times, are considered sometimes-used
+threshold_frequent = 25;	// tags used more than sometimes, but under this many times, are considered frequently-used
+threshold_normal = 50;		// tags used more than frequently, but under this many times, are considered normally-used
+// tags used more than normally will be considered always-used
+
 //global counters
 totalposts = 0;
 totaltags = 0;
@@ -123,16 +134,16 @@ function generateFlowers(tags)
         number = tags[t];
 		frequency = '';
 		
-		if (number < 5) {
+		if (number < threshold_barely) {
 		frequency = 'barely';
 		}
-		else if (number < 12) {
+		else if (number < threshold_sometimes) {
 		frequency = 'sometimes';
 		}
-		else if (number < 25) {
+		else if (number < threshold_frequent) {
 		frequency = 'frequent';
 		}
-		else if (number < 50) {
+		else if (number < threshold_normal) {
 		frequency = 'normal';
 		}
 		else {

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -67,12 +67,7 @@ function getTags(user_url)
 		//process and add the tags into the tags array
 		for (var i=0;i<data.response.posts.length;i++){
 			for (var j=0;j<data.response.posts[i].tags.length;j++){
-				temp_tag = data.response.posts[i].tags[j];
-				
-				if( caseInsensitive )
-				{
-					temp_tag = temp_tag.toLowerCase();
-				}
+				temp_tag = sanitizeTagForList( data.response.posts[i].tags[j] );
 				
 				if (tags[temp_tag]) {
 					tags[temp_tag]++;
@@ -111,6 +106,35 @@ function getTags(user_url)
 	}
 }
 
+//adjust the tag name so that it can be used in a list of tags to be counted
+function sanitizeTagForList(tag_name)
+{
+	sanitized_tag_name = tag_name;
+	
+	if( caseInsensitive )
+	{
+		sanitized_tag_name = sanitized_tag_name.toLowerCase();
+	}
+	
+	// The addition of quotes here avoids problems with reserved words, like "pop"
+	// We will need to remove the quotes later.
+	sanitized_tag_name = '"' + sanitized_tag_name + '"';
+	
+	return sanitized_tag_name;
+}
+
+//Prepare the tag to be displayed, undoing the weird things we did to sanitize it
+function getTagName(t)
+{
+	tag_name = t;
+	
+	// Remove the double-quotes from the beginning and end of the tag-name
+	// which were added in sanitizeTagForList
+	tag_name = tag_name.substring( 1, tag_name.length - 1 );
+	
+	return tag_name;
+}
+
 //adjust the tag name so that it will work as a URL for that tag
 function sanitizeTagForURL(tag_name)
 {
@@ -142,7 +166,8 @@ function generateFlowers(tags)
 	
 	for (var i=0;i<sortedTags.length;i++){
 		t = sortedTags[i];
-        number = tags[t];
+      		number = tags[t];
+		tag_name = getTagName(t);
 		frequency = '';
 		
 		if (number < threshold_barely) {
@@ -161,9 +186,9 @@ function generateFlowers(tags)
 		frequency = 'always';
 		}
 		
-		tag_url = "/tagged/" + sanitizeTagForURL(t);
+		tag_url = "/tagged/" + sanitizeTagForURL(tag_name);
 		
-		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + "" + " (" + number + ") </a></li>";
+		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ tag_name + "" + " (" + number + ") </a></li>";
 	}
 	flower += "</ul>";	
 	

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -114,7 +114,7 @@ function generateFlowers(tags)
 	
 	if (sum < totaltags) { console.log('not ready ' + sum + "/" + total); return 'loading' + sum + "/" + total;}
 	
-	flower = "<ul id='tag_info' style='width:800px;'>";
+	flower = "<ul id='tag_info'>";
 	sortedTags = getSortedKeys(tags);
 	console.log(sortedTags);	//prints the sorted tags in descending order
 	

--- a/tumblrtags.js
+++ b/tumblrtags.js
@@ -89,6 +89,19 @@ function getTags(user_url)
 	}
 }
 
+function sanitizeTagForURL(tag_name)
+{
+	sanitized_tag_name = tag_name;
+
+	// replace spaces with hyphens
+	sanitized_tag_name = sanitized_tag_name.replace(/\s+/g, '-');
+	
+	// replace apostrophes with URL encoding
+	sanitized_tag_name = sanitized_tag_name.replace(/[']/g, '%27');
+	
+	return sanitized_tag_name;
+}
+
 //generate the pretty html that you'll use on your page
 function generateFlowers(tags)
 {
@@ -125,7 +138,9 @@ function generateFlowers(tags)
 		frequency = 'always';
 		}
 		
-		flower += "<li class='tagitem'><a href='/tagged/"+t.replace(/\s+/g, '-')+"' class='" + frequency + "'>"+ t + " " + number +"</a></li>";
+		tag_url = "/tagged/" + sanitizeTagForURL(t);
+		
+		flower += "<li class='tagitem'><a href='" + tag_url + "' class='" + frequency + "'>"+ t + " " + number + "</a></li>";
 	}
 	flower += "</ul>";	
 	


### PR DESCRIPTION
- Moved the code for turning spaces into dashes into a new sanitizeTagForURL function, and added the ability to also escape apostrophes (fixes Issue #2)
- Added ability to handle reserved words (fixes Issue #1)
- Added the option to count and display the tags in a case-insensitive way
- Made frequency thresholds into variables near the top, to hopefully make them easier to tweak for users
- Changed display of tags to now have the tag count in parentheses
- Removed hard-coded list width (leaving it to user's CSS)
- Eliminated redundant header from HTML template.